### PR TITLE
Print reports to stdout

### DIFF
--- a/android-check-plugin/build.gradle
+++ b/android-check-plugin/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 }
 
 group = 'com.noveogroup.android'
-version = '1.2.3'
+version = '1.3.0-SNAPSHOT'
 description = 'Static code analysis plugin for Android project.'
 
 task wrapper(type: Wrapper) {

--- a/android-check-plugin/src/main/groovy/com/noveogroup/android/check/common/CommonCheck.groovy
+++ b/android-check-plugin/src/main/groovy/com/noveogroup/android/check/common/CommonCheck.groovy
@@ -60,6 +60,16 @@ abstract class CommonCheck<Config extends CommonConfig> {
         }
     }
 
+    protected void reformatReport(Project project, File styleFile,
+                                  File xmlReportFile) {
+        def temp = File.createTempFile('android-check', '.txt')
+        project.ant.xslt(in: xmlReportFile, out: temp) {
+            style { string(styleFile.text) }
+        }
+        System.out << temp.text
+        System.out.flush()
+    }
+
     void apply(Project target) {
         target.task(
                 [group      : 'verification',
@@ -72,6 +82,7 @@ abstract class CommonCheck<Config extends CommonConfig> {
             boolean abortOnError = config.resolveAbortOnError(extension.abortOnError)
             File configFile = config.resolveConfigFile(taskCode)
             File styleFile = config.resolveStyleFile(taskCode)
+            File stdoutStyleFile = config.resolveStdoutStyleFile(taskCode)
             File xmlReportFile = config.resolveXmlReportFile(taskCode)
             File htmlReportFile = config.resolveHtmlReportFile(taskCode)
             List<File> sources = config.getAndroidSources()
@@ -83,6 +94,7 @@ abstract class CommonCheck<Config extends CommonConfig> {
                 performCheck(target, sources, configFile, xmlReportFile)
                 htmlReportFile.parentFile.mkdirs()
                 reformatReport(target, styleFile, xmlReportFile, htmlReportFile)
+                reformatReport(target, stdoutStyleFile, xmlReportFile)
 
                 int errorCount = getErrorCount(xmlReportFile)
                 if (errorCount) {

--- a/android-check-plugin/src/main/groovy/com/noveogroup/android/check/common/CommonConfig.groovy
+++ b/android-check-plugin/src/main/groovy/com/noveogroup/android/check/common/CommonConfig.groovy
@@ -138,11 +138,23 @@ class CommonConfig {
         return Utils.getResource(project, "$code/${code}.xsl")
     }
 
+    private String resolveStdoutStyle(String code) {
+        return Utils.getResource(project, "$code/${code}.stdout.xsl")
+    }
+
     File resolveStyleFile(String code) {
         File file = new File(project.buildDir, "tmp/android-check/${code}.xsl")
         file.parentFile.mkdirs()
         file.delete()
         file << resolveStyle(code)
+        return file
+    }
+
+    File resolveStdoutStyleFile(String code) {
+        File file = new File(project.buildDir, "tmp/android-check/${code}.stdout.xsl")
+        file.parentFile.mkdirs()
+        file.delete()
+        file << resolveStdoutStyle(code)
         return file
     }
 

--- a/android-check-plugin/src/main/resources/checkstyle/checkstyle.stdout.xsl
+++ b/android-check-plugin/src/main/resources/checkstyle/checkstyle.stdout.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+    <xsl:output indent="yes" method="text" />
+    <xsl:decimal-format decimal-separator="." grouping-separator="," />
+
+    <xsl:key name="files" match="file" use="@name" />
+
+    <xsl:template match="checkstyle">
+    Checkstyle: <xsl:apply-templates mode="summary" select="." />
+        Files: <xsl:apply-templates select="file[@name and generate-id(.) = generate-id(key('files', @name))]" />
+
+    </xsl:template>
+
+    <xsl:template match="file">
+        <xsl:variable name="errorCount" select="count(error)" />
+            - <xsl:value-of select="@name" />
+                Errors: <xsl:value-of select="$errorCount" />
+                <xsl:for-each select="key('files', @name)/error">
+                    <xsl:sort data-type="number" order="ascending" select="@line" />
+                    Error Description: <xsl:value-of select="@message" />
+                        Line: <xsl:value-of select="@line" />
+                </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="checkstyle" mode="summary">
+        <xsl:variable name="fileCount" select="count(file[@name and generate-id(.) = generate-id(key('files', @name))])" />
+        <xsl:variable name="errorCount" select="count(file/error)" />
+        Summary:
+            Files: <xsl:value-of select="$fileCount" />
+            Errors: <xsl:value-of select="$errorCount" />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/android-check-plugin/src/main/resources/findbugs/findbugs.stdout.xsl
+++ b/android-check-plugin/src/main/resources/findbugs/findbugs.stdout.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+    <xsl:output indent="yes" method="text" />
+    <xsl:decimal-format decimal-separator="." grouping-separator="," />
+
+    <xsl:template match="BugCollection">
+    Findbugs: <xsl:apply-templates mode="summary" select="." />
+        Files: <xsl:apply-templates select="FindBugsSummary/FileStats[@path and @bugCount]" />
+
+    </xsl:template>
+
+    <xsl:template match="FileStats">
+        <xsl:variable name="path" select="@path" />
+            - <xsl:value-of select="$path" />
+                Errors: <xsl:value-of select="@bugCount" />
+            <xsl:for-each select="//BugInstance[SourceLine/@sourcepath = $path]">
+                <xsl:sort data-type="number" order="ascending" select="SourceLine/@start" />
+                    Error Description: <xsl:value-of select="@type" />
+                        Line: <xsl:value-of select="LongMessage/text()" />
+                        <xsl:value-of select="SourceLine/@start" /> - <xsl:value-of select="SourceLine/@end" />
+            </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="BugCollection" mode="summary">
+        <xsl:variable name="fileCount" select="count(FindBugsSummary/FileStats)" />
+        <xsl:variable name="errorCount" select="count(BugInstance)" />
+        Summary:
+            Files: <xsl:value-of select="$fileCount" />
+            Errors: <xsl:value-of select="$errorCount" />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/android-check-plugin/src/main/resources/pmd/pmd.stdout.xsl
+++ b/android-check-plugin/src/main/resources/pmd/pmd.stdout.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+    <xsl:output indent="yes" method="text" />
+    <xsl:decimal-format decimal-separator="." grouping-separator="," />
+
+    <xsl:key name="files" match="file" use="@name" />
+
+    <xsl:template match="pmd">
+    PMD: <xsl:apply-templates mode="summary" select="." />
+        Files: <xsl:apply-templates select="file[@name and generate-id(.) = generate-id(key('files', @name))]" />
+
+    </xsl:template>
+
+    <xsl:template match="file">
+        <xsl:variable name="violationCount" select="count(violation)" />
+        - <xsl:value-of select="@name" />
+            Violations: <xsl:value-of select="$violationCount" />
+            <xsl:for-each select="key('files', @name)/violation">
+                <xsl:sort data-type="number" order="ascending" select="@beginline" />
+                Violation: <xsl:value-of select="normalize-space(node())" />
+                    Location: <xsl:value-of select="@beginline" />:<xsl:value-of select="@begincolumn" /> - <xsl:value-of select="@endline" />:<xsl:value-of select="@endcolumn" />
+            </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="pmd" mode="summary">
+        <xsl:variable name="fileCount" select="count(file[@name and generate-id(.) = generate-id(key('files', @name))])" />
+        <xsl:variable name="violationCount" select="count(file/violation)" />
+        Summary:
+            Files: <xsl:value-of select="$fileCount" />
+            Violations: <xsl:value-of select="$violationCount" />
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Implements outputting of the error reports to standard output.  This gives useful output from the plugin on Travis CI, where the XML and HTML output can't be easily accessed.

If this looks useful there is a bit of cleanup that could obviously done:
- allow disabling of this feature (likely it should be off by default)
- make variable and file names a bit clearer to differentiate between stdout and HTML transformations

Issue: #20
